### PR TITLE
fix: Stop filenames which are not valid regular expressions  crashing

### DIFF
--- a/adbren.pl
+++ b/adbren.pl
@@ -184,7 +184,8 @@ foreach my $filepath (@files) {
         open my $log, "<", $logfile;
         $/ = 1;
         my @raw_data = <$log>;
-        my @matches = grep { /$filename/ } @raw_data;
+        my $filename_qm = quotemeta $filename;
+        my @matches = grep { /$filename_qm/ } @raw_data;
         if ( scalar @matches > 0 ) {
             print "Skipped: $filename\n";
             next;


### PR DESCRIPTION
When you generate a filename that contains square brackets, and a hyphen within that, the skip checking code can subsequently crash if the characters either side of the hyphen do not form a valid range.

For example, "[i-S]" in a filename will crash.

Given that this check is meant to be searching for existing items, not actually applying a regular expression, I've used `quotemeta` on the whole filename.